### PR TITLE
Remove extraneous colors from solution grid

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -1283,9 +1283,6 @@ static void show_results(game_t* core)
         core->tile[23].letter = valid_answer[3];
         core->tile[24].letter = valid_answer[4];
 
-        core->tile[6].state   = CORRECT_LETTER;
-        core->tile[13].state  = WRONG_POSITION;
-
         core->tile[20].state  = CORRECT_LETTER;
         core->tile[21].state  = CORRECT_LETTER;
         core->tile[22].state  = CORRECT_LETTER;


### PR DESCRIPTION
Word 2, letter 2 (tile 6) and word 3, letter 4 (tile 13) were hardcoded to show colors in the solution display instead of the ones actually used in the puzzle.

Fixes #18 